### PR TITLE
add applications.commands to the invite link for future-proofing

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,8 @@ bot = commands.Bot(command_prefix=':3 ')
 @bot.command(name='invite', help='gives bot invite')
 async def invite(ctx):
     response = 'the bot invite is:  ' \
-               'https://discord.com/api/oauth2/authorize?client_id=879069038695817216&permissions=8&scope=bot'
+               'https://discord.com/api/oauth2/authorize?client_id=879069038695817216' \
+               '&permissions=8&scope=bot%20applications.commands'
     await ctx.send(response)
 
 


### PR DESCRIPTION
This is important (or will be in the future). With the pending removal of message intent permissions, discord is trying to force a shift to slash commands. To do so, the `applications.commands` scope is needed. Adding it now will make it easier to adapt in the future. This won't apply to servers the bot is currently in though